### PR TITLE
Segmentation action modified with a new array of surfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ add_message_files(
   Program.msg
   ProgramInfo.msg
   ProgramInfoList.msg
+  Surface.msg
   Step.msg
 )
 

--- a/action/SegmentSurfaces.action
+++ b/action/SegmentSurfaces.action
@@ -1,5 +1,6 @@
 bool save_cloud # True if the point cloud should be saved
 ---
 rapid_pbd_msgs/Landmark[] landmarks
+rapid_pbd_msgs/Surface surface
 string cloud_db_id # MongoDB id of the cloud, if saved
 ---

--- a/action/SegmentSurfaces.action
+++ b/action/SegmentSurfaces.action
@@ -1,6 +1,5 @@
 bool save_cloud # True if the point cloud should be saved
 ---
 rapid_pbd_msgs/Landmark[] landmarks
-moveit_msgs/CollisionObject[] surfaces
 string cloud_db_id # MongoDB id of the cloud, if saved
 ---

--- a/action/SegmentSurfaces.action
+++ b/action/SegmentSurfaces.action
@@ -1,5 +1,6 @@
 bool save_cloud # True if the point cloud should be saved
 ---
 rapid_pbd_msgs/Landmark[] landmarks
+moveit_msgs/CollisionObject[] surfaces
 string cloud_db_id # MongoDB id of the cloud, if saved
 ---

--- a/msg/Surface.msg
+++ b/msg/Surface.msg
@@ -1,0 +1,5 @@
+# Topic: rapid_pbd/surface
+# Message for collision surface information
+
+geometry_msgs/PoseStamped pose_stamped # The pose of center of the table. Should be specified in the base frame.
+geometry_msgs/Vector3 dimensions # Dimensions of the table, in meters

--- a/msg/Surface.msg
+++ b/msg/Surface.msg
@@ -1,5 +1,3 @@
-# Topic: rapid_pbd/surface
-# Message for collision surface information
-
+# Information of a collision surface for collision object construction
 geometry_msgs/PoseStamped pose_stamped # The pose of center of the table. Should be specified in the base frame.
 geometry_msgs/Vector3 dimensions # Dimensions of the table, in meters

--- a/msg/Surface.msg
+++ b/msg/Surface.msg
@@ -1,3 +1,3 @@
-# Information of a collision surface for collision object construction
+# Represents a surface found when detecting surface objects.
 geometry_msgs/PoseStamped pose_stamped # The pose of center of the table. Should be specified in the base frame.
 geometry_msgs/Vector3 dimensions # Dimensions of the table, in meters


### PR DESCRIPTION
See the [contribution checklist](https://github.com/jstnhuang/rapid_pbd/blob/indigo-devel/.github/CONTRIBUTING.md).

One-line description of pull request:
A surface array added for surface segmentation

Detailed description of pull request:
SegmentSurfaces.action now has an additional array for collision surfaces as result of an action. This allows surface_segmentation_action to add detected collision surfaces in the result. Although current development of surface_segmentation_action only adds one collision surface, this pull request enables potential of surface_segmentation_action to add multiple collision surfaces.

How was this PR tested?
Tested by demo video: https://drive.google.com/open?id=0B5qgkEBlR0dXVkNUZWhSVExyUm8